### PR TITLE
Added .map() instead of .forEach()

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -145,13 +145,10 @@ class Database extends Base {
         if (typeof limit !== "number" || limit < 1) limit = 0;
         let data = await this.schema.find().catch(e => {});
         if (!!limit) data = data.slice(0, limit);
-        let comp = [];
-        data.forEach(c => {
-            comp.push({
-                ID: c.ID,
-                data: c.data
-            });
-        });
+        comp = data.map(x => {
+            ID: x.ID,
+            data: x.data
+        })
         return comp;
     }
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -145,7 +145,10 @@ class Database extends Base {
         if (typeof limit !== "number" || limit < 1) limit = 0;
         let data = await this.schema.find().catch(e => {});
         if (!!limit) data = data.slice(0, limit);
-        comp = data.map(x => ({ ID: x.ID, data: x.data }))
+        let comp = []
+        for(i in data){
+            comp.push({ ID: data[i].ID, data: data[i].data })
+        }
         return comp;
     }
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -146,7 +146,7 @@ class Database extends Base {
         let data = await this.schema.find().catch(e => {});
         if (!!limit) data = data.slice(0, limit);
         let comp = []
-        for(i in data){
+        for(let i = 0; i < data.length; i++){
             comp.push({ ID: data[i].ID, data: data[i].data })
         }
         return comp;

--- a/src/Main.js
+++ b/src/Main.js
@@ -145,9 +145,7 @@ class Database extends Base {
         if (typeof limit !== "number" || limit < 1) limit = 0;
         let data = await this.schema.find().catch(e => {});
         if (!!limit) data = data.slice(0, limit);
-        comp = data.map(x => {
-            return { ID: x.ID, data: x.data }
-        })
+        comp = data.map(x => ({ ID: x.ID, data: x.data }))
         return comp;
     }
 

--- a/src/Main.js
+++ b/src/Main.js
@@ -31,7 +31,7 @@ class Database extends Base {
      * @param {string} key Key
      * @param value Data
      * @example db.set("foo", "bar").then(() => console.log("Saved data"));
-     */
+     */ 
     async set(key, value) {
         if (!Util.isKey(key)) throw new Error("Invalid key specified!", "KeyError");
         if (!Util.isValue(value)) throw new Error("Invalid value specified!", "ValueError");

--- a/src/Main.js
+++ b/src/Main.js
@@ -146,8 +146,7 @@ class Database extends Base {
         let data = await this.schema.find().catch(e => {});
         if (!!limit) data = data.slice(0, limit);
         comp = data.map(x => {
-            ID: x.ID,
-            data: x.data
+            return { ID: x.ID, data: x.data }
         })
         return comp;
     }


### PR DESCRIPTION
Before:
```js
async all(limit = 0) {
        if (typeof limit !== "number" || limit < 1) limit = 0;
        let data = await this.schema.find().catch(e => {});
        if (!!limit) data = data.slice(0, limit);
        let comp = [];
        data.forEach(c => {
            comp.push({
                ID: c.ID,
                data: c.data
            });
        });
        return comp;
}
```

After
```js
async all(limit = 0) {
        if (typeof limit !== "number" || limit < 1) limit = 0;
        let data = await this.schema.find().catch(e => {});
        if (!!limit) data = data.slice(0, limit);
        let comp = data.map(x => {
            ID: x.ID,
            data: x.data
        })
        return comp;
}
```

I guess this will be better instead of using forEach